### PR TITLE
Fix minor typos and simplify syntax

### DIFF
--- a/_episodes/01-software-development-intro.md
+++ b/_episodes/01-software-development-intro.md
@@ -26,7 +26,7 @@ more specifically, the Model-View-Control design architecture used by the exampl
 over the course of this workshop. There are other things to consider early on in software development - for example, 
 [choosing a license](/32-preparing-software-reuse/index.html#choosing-an-open-source-licence) for your 
 project or [writing documentation](/32-preparing-software-reuse/index.html#documenting-code-to-improve-reusability). 
-For the purposes of this workshop we cover them later, but be aware that in the normal run of the things they should 
+For the purposes of this workshop we will cover them later, but be aware that in the normal run of things they should be
 addressed early.
 
 ## Software Architectures
@@ -37,7 +37,7 @@ a software system that describes high-level components (modules) of the system a
 In software design and development, large systems or programs are often decomposed into a set of smaller 
 modules each with a subset of functionality. Typical examples of modules in programming are software libraries; 
 some software libraries, such as `numpy` and `matplotlib` in Python, are bigger modules that contain several 
-smaller sub-modules. Another examples of modules are classes in object-oriented programming languages. 
+smaller sub-modules. Another example of modules are classes in object-oriented programming languages. 
 
 > ## Programming modules and interfaces
 > Although modules are self-contained and independent elements to a large extent (they can depend on other modules), 
@@ -138,27 +138,26 @@ should use a pre-generated personal access token as your password here.
 > > 1. Find the URL of the software project repository to clone from your GitHub account. Make sure you do not clone the 
 >original template repository but rather your own copy, as you should be able to push commits to it later on.
 > > 2. Do:    
-> > `$git clone https://github.com/<YOUR_GITHUB_USERNAME>/python-intermediate-inflammation` 
+> > `git clone https://github.com/<YOUR_GITHUB_USERNAME>/python-intermediate-inflammation` 
 > > 3. Navigate into the cloned repository in your command line shell:    
-> > `$cd python-intermediate-inflammation`
+> > `cd python-intermediate-inflammation`
 > > 4. List the contents of the directory:  
-> > `$ls -l`  
-> > Remember the `-l` flag of the `ls` command and also how to get help for commands in shell: `$man ls`.
+> > `ls -l`  
+> > Remember the `-l` flag of the `ls` command and also how to get help for commands in shell: `man ls`.
 > {: .solution}   
 >
 {: .challenge}       
 
-Let’s inspect the software project. In your shell from the project root issue the command `$ls -l` to get the more detailed
+Let’s inspect the software project. In your shell from the project root issue the command `ls -l` to get the more detailed
 listing of the contents of your project directory. You should see something similar to the following.
 ~~~
-$ls -l
+$ ls -l
 total 24
--rw-r--r--   1 user  staff   253 20 Apr 15:41 Makefile
--rw-r--r--   1 user  staff  1055 20 Apr 15:41 README.md
-drwxr-xr-x  18 user  staff   576 20 Apr 15:41 data
-drwxr-xr-x   5 user  staff   160 20 Apr 15:41 inflammation
--rw-r--r--   1 user  staff  1122 20 Apr 15:41 patientdb.py
-drwxr-xr-x   4 user  staff   128 20 Apr 15:41 tests
+-rw-r--r--   1 carpentry  users  1055 20 Apr 15:41 README.md
+drwxr-xr-x  18 carpentry  users   576 20 Apr 15:41 data
+drwxr-xr-x   5 carpentry  users   160 20 Apr 15:41 inflammation
+-rw-r--r--   1 carpentry  users  1122 20 Apr 15:41 patientdb.py
+drwxr-xr-x   4 carpentry  users   128 20 Apr 15:41 tests
 ~~~
 {: .language-bash}
 
@@ -171,7 +170,7 @@ a series of comma-separated values (CSV) format files, where:
 - columns represent successive days.
 
 File `patientdb.py` is the Controller module that performs basic statistical analysis over data and provides the main 
-entry point in the application too (as it contains the `main()` function). Directory tests contains several tests that 
+entry point in the application too (as it contains the `main()` function). Directory `tests` contains several tests that 
 have been implemented already, some of which are currently failing. These failing tests set out the requirements for 
 the additional code to be implemented during the workshop.
 


### PR DESCRIPTION
* Remove Makefile from `ls -l` output
* Remove `$` from commands - it was somewhat confusing, making it look like `$` was part of the command.
