### PR TITLE
Addressed comments from internal pilot #2 on IDEs.

### DIFF
--- a/_episodes/02-ides.md
+++ b/_episodes/02-ides.md
@@ -36,8 +36,8 @@ and font effects
 - Version control support - to interact with source code repositories
 - Debugging - for setting breakpoints in the code editor, step-by-step execution of code and inspection of variables
 
-IDEs are extremely useful and modern software development would be very hard without them. There is a number of IDEs
-available for Python development, a good overview is available from the
+IDEs are extremely useful and modern software development would be very hard without them. There are a number of IDEs
+available for Python development; a good overview is available from the
 [Python Project Wiki](https://wiki.python.org/moin/IntegratedDevelopmentEnvironments). In addition to IDEs,
 there is also a number of code editors that have
 Python support. Code editors can be as simple as a text editor with syntax highlighting and code formatting capabilities
@@ -60,7 +60,10 @@ Select `Open` and find the software project repository you cloned earlier, and s
 directory. This directory is now the current working directory for PyCharm, so when we run scripts from PyCharm,
 this is the directory they will run from.
 
-PyCharm will show you a 'Tip of the Day' window which you can safely ignore by selecting `Close`.
+PyCharm will show you a *'Tip of the Day'* window which you can safely ignore and close for now. You may also get a 
+warning *'No Python interpreter configured for the project'* - we [will deal with this](#configuring-pycharm-with-anaconda) 
+shortly after we familiarise ourselves with 
+the PyCharm environment.
 You will notice the IDE shows you a project/file navigator window on the left hand side, to traverse and select the files
 (and any subdirectories) within the working directory, and an editor window on the right. At the bottom, you would 
 typically have a panel for version control, terminal (command line shell within PyCharm) and a TODO list.
@@ -106,13 +109,13 @@ associated with a different version control system. Our project was already unde
 recognised it. It is also possible to add an unversioned project directory to version control directly from PyCharm.
 
 For the purposes of this workshop, we will do all our version control commands from the shell but it is worth
-noting that PyCharm offers a *comprehensive subset** of Git commands (i.e. it is possible to perform a set of common
+noting that PyCharm offers a **comprehensive subset** of Git commands (i.e. it is possible to perform a set of common
 Git commands from PyCharm but not all). A very useful version control feature in PyCharm is graphically comparing
 changes you made locally to a file with the same repository version, a different commit version or a version in a different
 branch - this is something that cannot be done equally well from a text-based shell terminal. 
 
-You can get full
-[documentation on PyCharm build-in version control](https://www.jetbrains.com/help/pycharm/version-control-integration.html) online.
+You can get a full
+[documentation on PyCharm's built-in version control support](https://www.jetbrains.com/help/pycharm/version-control-integration.html) online.
 
 Note that you can only do 
 comparison of changes if you have actually modified your files locally. You can try this out now if you modify 
@@ -125,18 +128,18 @@ any file - for example add a blank line anywhere in `patientdb.py` then navigate
 
 ### Configuring PyCharm with Anaconda
 Our software project already contains some Python code (scripts). PyCharm (and IDEs in general) allow you to run the code
-from within the IDE. An alternative is to use the IDE for code development and then run the code from the command line shell.
+from within the IDE. An alternative is to use the IDE for code development and then run the code from the command line.
 Either way of running code is fine - you just have to make sure that you have all the necessary dependencies (libraries/packages) installed
 in whichever environment you choose to run your code from (as these two methods are typically independent from one another). It is good however 
 to be familiar with both and choose the one that suits you and your particular situation - running code from a command line is 
 good as it forces you to get more familiar with running scripts from a shell which is then applicable to many other programming languages. 
 
-Before you can run the code from PyCharm, you need to configure
-it so that it knows where the Python interpreter, which we want to use to run the code, is located. The same goes for any
-dependencies your code may have - you need to tell PyCharm where to find them. In our case, we want to use the Python 
+Before you can run the code from PyCharm, you need to explicitly to specify the path to the Python 
+interpreter executable on your system. The same goes for any dependencies your code may have - you need to tell PyCharm 
+where to find them. In our case, we want to use the Python 
 interpreter and extra packages that are supplied with the Anaconda Python distribution. However, you may have
 various Python distributions and versions installed on your system so you have to be careful here to select the one you
-want to use.
+want to use from PyCharm.
 
 #### Adding a Python Interpreter in PyCharm
 1. Select either `PyCharm` > `Preferences` (Mac) or `File` > `Settings` (Linux, Windows).
@@ -144,7 +147,7 @@ want to use.
 `Project Interpreter` from the left. You'll
 see a number of Python packages displayed as a list, and importantly above that, the current Python interpreter that is
 being used. These may be blank or set to `<No interpreter>`, or possibly the default version of Python installed on your system, e.g. `Python 2.7 /usr/bin/python2.7`
-or `Python 3.7 /usr/bin/python3.7`, which we do not want to use in this instance - we want to use Anaconda
+or `Python 3.8 /usr/bin/python3.8`, which we do not want to use in this instance - we want to use Anaconda
 distribution of Python.
 3. Select the cog-like button in the top right, then `Add Local...` (or `Add...` depending on your version). An `Add Local Python Interpreter` window will appear.
 4. Select `Conda Environment` from the list on the left so we can configure an Anaconda environment, and ensure that `New environment` is
@@ -152,7 +155,7 @@ selected. In the `Location` field, you'll see something like `/Users/<USERNAME>/
    system. Replace the `python-intermediate-inflammation` part of the field with `patient` - which is a name we'll use to refer to this environment later on.
 5. Select `Make available to all projects` so we can also use this environment with other projects if we wish.
 6. Select `OK` in the `Add Python Interpreter` window. Back in the `Preferences` window, you should select
-`Python 3.7 (patient)` or similar from the `Project Interpreter` drop-down list.
+`Python 3.8 (patient)` or similar from the `Project Interpreter` drop-down list.
 
 #### Adding Additional Packages
 7. We also need to add the packages `numpy` and `matplotlib` to this environment, since our software uses them. In this window select the `+` icon at the bottom
@@ -168,7 +171,7 @@ we can configure these for our project:
 
 1. To add a new configuration for a project - select `Run` > `Edit Configurations...` from the top menu.
 2. Select `+` button from the top left to add a configuration, selecting `Python` from the drop down list. You should see
-`Python 3.7 (patient)` or similar in the `Python interpreter` field in the window. For `Script path`, select the folder
+`Python 3.8 (patient)` or similar in the `Python interpreter` field in the window. For `Script path`, select the folder
 button and find and select `patientdb.py`. This tells PyCharm which script to run.
 You can even give this configuration a name at the top of the window if you like - let's name it `patient`.
 3. Select `OK` to confirm these settings.
@@ -177,7 +180,11 @@ You can even give this configuration a name at the top of the window if you like
 >
 > By configuring the Python interpreter to use in PyCharm, we have created a new Python configuration within which our
 > code will can run. These configurations are commonly known as *virtual environments*, and we will cover them in more detail in the
-> [next episode](../03-virtual-environments/index.html).
+> [next episode](../03-virtual-environments/index.html). Note that you can create several configurations 
+> based on the same Python interpreter - this is helpful when you need to create different virtual environments for 
+> developing different types of applications. For example, you can create one virtual environment based on Python 3.8 
+> to develop Django Web applications and another virtual environment based on the same Python 3.8 to work with 
+> scientific libraries.
 {: .callout}
 
 Once done, you are ready to run your script from PyCharm!
@@ -199,8 +206,7 @@ Here, we can see that a new shell has been created that uses the Anaconda interp
 `/Users/alex/anaconda/envs/patient/bin/python` from the virtual environment `patient` we just created in PyCharm to run our
 script located at `/Users/alex/python-intermediate-inflammation/patientdb.py`. The script is currently throwing an error -
 `patientdb.py: error: the following arguments are required: infiles`.
-Do not worry about it for now, we will learn how to fix the errors and write test
-to detect errors in the following episodes.
+We will learn how to fix the errors and write tests to detect errors in the following episodes. 
 
 {% include links.md %}
 


### PR DESCRIPTION
Comment form pilot #2

Renato] After opening a project PyCharm warns that no Python interpreter has been set.
This is covered later in the lesson so perhaps a forward reference to “Adding a Python Interpreter in PyCharm” would be helpful.
[Renato] version control in pycharm: Minor formatting typo in “comprehensive subset”
[Renato] Build-in -> built-in
[Renato] Adding a Python interpreter in PyCharm: Conda 3 defaults to 3.8 now so some references to 3.7 may be out of date.
[Renato] Configuring PyCharm with Anaconda: Confusing use of Anaconda vs Conda. Anaconda already includes “numpy” and “matplotlib” so adding those to the environment was unexpected here.
[Pip] PyCharm: The shortcut bindings can differ if people have preconfigured pycharm to use for example vim bindings
[Sam] There is a number of IDEs available for Python development, -> There are
[Sam] it is worth noting that PyCharm offers a *comprehensive subset** of Git -> it is worth noting that PyCharm offers a **comprehensive subset** of Git 
[Sam] Do not worry about it for now, we will learn how to fix the errors and write test to detect errors in the following episodes. -> we will learn how to fix the errors and write tests to detect errors in the following episodes 
[Sam] The section on configuring an interpreter is a bit unclear. The user has to follow along and jump through a bunch of hoops but they may not really understand why PyCharm can’t simply find their default python install. It would benefit from a brief explanation of why you can select different interpreters (possibly in a callout) that mentions they’ll be discussed in more detail later.
