### PR TITLE
Addressed comments from internal pilot #2 on code convention.

### DIFF
--- a/_episodes/05-coding-convention.md
+++ b/_episodes/05-coding-convention.md
@@ -138,8 +138,8 @@ line continuation (slightly less preferred method).
 if (a == True and 
     b == False):
 
-# Using a backslash (/) for line continuation
-if a == True and /
+# Using a backslash (\) for line continuation
+if a == True and \
     b == False:
  ~~~
 {: .language-python}
@@ -149,7 +149,7 @@ Lines should break before binary operators so that the operators do not get scat
 on the screen. In the example below, the eye does not have to do the extra work to tell which items are added
 and which are subtracted:
 ~~~
-# Correct - easy to match operators with operands
+# PEP 8 compliant - easy to match operators with operands
 income = (gross_wages
           + taxable_interest
           + (dividends - qualified_dividends)
@@ -166,10 +166,10 @@ should be surrounded by a single blank line. You can use blank lines in function
 Avoid extraneous whitespace in the following situations:
 - immediately inside parentheses, brackets or braces
     ~~~
-    # Correct:
+    # PEP 8 compliant:
     my_function(colour[1], {id: 2})
 
-    # Wrong:
+    # Not PEP 8 compliant:
     my_function( colour[ 1 ], { id: 2 } )
     ~~~
     {: .language-python}
@@ -177,42 +177,44 @@ Avoid extraneous whitespace in the following situations:
 - Immediately before a comma, semicolon, or colon (unless doing slicing where the colon acts like a binary operator
 in which case it should should have equal amounts of whitespace on either side)
     ~~~
-    # Correct:
-    if x == 4: print x, y; x, y = y, x
+    # PEP 8 compliant:
+    if x == 4: print(x, y); x, y = y, x
 
-    # Wrong:
-    if x == 4 : print x , y ; x , y = y , x
+    # Not PEP 8 compliant:
+    if x == 4 : print(x , y); x , y = y, x
     ~~~
     {: .language-python}
 
 - Immediately before the open parenthesis that starts the argument list of a function call
     ~~~
-    # Correct:
+    # PEP 8 compliant:
     my_function(1)
 
-    # Wrong:
+    # Not PEP 8 compliant:
     my_function (1)
     ~~~
     {: .language-python}
 
 - Immediately before the open parenthesis that starts an indexing or slicing
      ~~~
-    # Correct:
-    my_dct['key'] = my_lst[id]
+    # PEP 8 compliant:
+    my_dct['key'] = my_lst[id] 
+    first_char = my_str[:, 1]
 
-    # Wrong:
-    my_dct ['key'] = my_lst [id]
+    # Not PEP 8 compliant:
+    my_dct ['key'] = my_lst [id] 
+    first_char = my_str [:, 1]
      ~~~
      {: .language-python}
 
 - More than one space around an assignment (or other) operator to align it with another
      ~~~
-    # Correct:
+    # PEP 8 compliant:
     x = 1
     y = 2
     student_loan_interest = 3
 
-    # Wrong:
+    # Not PEP 8 compliant:
     x                     = 1
     y                     = 2
     student_loan_interest = 3
@@ -228,13 +230,13 @@ booleans (and, or, not).
 - Don't use spaces around the = sign when used to indicate a keyword argument assignment or to indicate a
 default value for an unannotated function parameter
      ~~~
-    # Correct use of spaces around = for variable assignment
+    # PEP 8 compliant use of spaces around = for variable assignment
     axis = 'x'
     angle = 90
     size = 450
     name = 'my_graph'
 
-    # Correct use of no spaces around = for keyword argument assignment in a function call
+    # PEP 8 compliant use of no spaces around = for keyword argument assignment in a function call
     my_function(
         1,
         2,
@@ -294,6 +296,12 @@ and this includes a future version of yourself. It can be easy to forget why you
 months' time. Write comments as complete sentences and in English unless you are 100% sure the code will never be read
 by people who don't speak your language.
 
+> ## The Good, the Bad, and the Ugly
+> Check out the ['Putting comments in code: the good, the bad, and the ugly' blogpost](https://www.freecodecamp.org/news/code-comments-the-good-the-bad-and-the-ugly-be9cc65fbf83/).
+> Remember - a comment should answer the ‘why’ question”. Occasionally the “what” question. 
+> The “how” question should be answered by the code itself. 
+{: .callout}
+
 Block comments generally apply to some (or all) code that follows them, and are indented to the same level as that
 code. Each line of a block comment starts with a `#` and a single space (unless it is indented text inside the comment).
 ~~~
@@ -308,7 +316,7 @@ An inline comment is a comment on the same line as a statement. Inline comments 
 spaces from the statement. They should start with a `#` and a single space and should be used sparingly.
 ~~~
 def fahr_to_cels(fahr):
-    cels = (fahr + 32) * (5 / 9) # Inline comment example: convert temperature in Fahrenheit to Celsius
+    cels = (fahr + 32) * (5 / 9)  # Inline comment example: convert temperature in Fahrenheit to Celsius
     return cels
 ~~~
 {: .language-python}
@@ -366,7 +374,7 @@ the discovered inconsistencies.
 >recommended for variable names. Rename it to, e.g. `infiles`.
 > >
 > > 3.There is an extra blank line on line 20 in `patientdb.py`. Normally, you should not use blank lines in the
-> > middle of the code unless you want to separate logical units - in which case only one blank like is used.
+> > middle of the code unless you want to separate logical units - in which case only one blank line is used.
 > > Note how PyCharm is warning us by underlying the whole line.
 > >
 > > 4.Only one blank line after the end of definition of function `main` and the rest of the code on line 30 in
@@ -382,7 +390,7 @@ Fibonacci number:
 def fibonacci(n):
     """Calculate the nth Fibonacci number.
 
-    A recursive implementation of Fibonacci.
+    A recursive implementation of Fibonacci array elements.
 
     :param n: integer
     :raises ValueError: raised if n is less than zero
@@ -404,9 +412,17 @@ Note here we are explicitly documenting our input variables, what is returned by
 act as a *contract* for readers to understand what to expect in terms of behaviour when using the function,
 as well as how to use it.
 
-A comment string like this is called a *docstring*. We do not need to use triple quotes when we write one, but
-if we do, we can break the string across multiple lines. This also applies to Python modules, which are essentially
-files of Python functions, or methods within classes and docstrings are used to list them all.
+A special comment string like this is called a **docstring**. We do not need to use triple quotes when writing one, but
+if we do, we can break the text across multiple lines. Docstrings can also be used at the start of a Python module (a file 
+containing a number of Python functions) or at the start of a Python class (containing a number of methods) to list 
+their contents as a reference. You should not confuse docstrings with comments though - docstrings are context-dependent and should only 
+be used in specific locations (e.g. at the top of a module and immediately after `class` and `def` keywords as mentioned). 
+Using triple quoted strings in locations where they will not be interpreted as docstrings or 
+using triple quotes as a way to 'quickly' comment out an entire block of code is considered bad practice. 
+
+In our example case, we used 
+the [Sphynx/ReadTheDocs docstring style](https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html) formatting 
+for the `param`, `raises` and `returns` - other docstring formats exist as well.
 
 > ## Python PEP 257 - Recommendations for Docstrings
 > PEP 257 is another one of Python Enhancement Proposals and this one deals with docstring conventions to
@@ -438,9 +454,10 @@ Functions:
 ~~~
 {: .language-python}
 
-Docstrings for a function or a module is returned when
-invoking `help` function and passing its name - for example from interactive `ipython` shell or from Jupyter Lab/Notebook
-or when rendering code documentation online (e.g. see [Python documentation](https://docs.python.org/3.7/library/index.html)).
+The docstring for a function or a module is returned when
+calling the `help` function and passing its name - for example from interactive `ipython` shell or from Jupyter Lab/Notebook 
+or when rendering code documentation online (e.g. see [Python documentation](https://docs.python.org/3.8/library/index.html)). 
+PyCharm also displays the docstring for a function/module in a little elp popup window when using tab-completion.
 
 ~~~
 help(fibonacci)
@@ -454,33 +471,33 @@ help(fibonacci)
 > > return values.
 > > ~~~
 > > def daily_mean(data):
-> >        """Calculate the daily mean of a 2D inflammation data array for each day.
+> >    """Calculate the daily mean of a 2D inflammation data array for each day.
 > >
-> >        :param data: A 2D data array containing inflammation data (each row contains measurments for a single day).
-> >        :returns: An array of mean values of measurements for each day.
-> >        """
-> >        return np.mean(data, axis=0)
+> >    :param data: A 2D data array with inflammation data (each row contains measurments for a single day across all patients).
+> >    :returns: An array of mean values of measurements for each day.
+> >    """
+> >    return np.mean(data, axis=0)
 > >    ~~~
 > > {: .language-python}
 > > ~~~
 > > def daily_min(data):
-> >        """Calculate the daily minimum of a 2D inflammation data array for each day.
+> >    """Calculate the daily minimum of a 2D inflammation data array for each day.
 > >
-> >        :param data: A 2D data array containing inflammation data (each row contains measurments for a single day).
-> >        :returns: An array of min values of measurements for each day.
-> >        """
-> >        return np.min(data, axis=0)
-> >    ~~~
+> >    :param data: A 2D data array with inflammation data (each row contains measurments for a single day across all patients).
+> >    :returns: An array of minimum values of measurements for each day.
+> >    """
+> >    return np.min(data, axis=0)
+> >~~~
 > > {: .language-python}
 > > ~~~
 > > def daily_max(data):
-> >        """Calculate the daily maximum of a 2D inflammation data array for each day.
+> >    """Calculate the daily maximum of a 2D inflammation data array for each day.
 > >
-> >        :param data: A 2D data array containing inflammation data (each row contains measurments for a single day).
-> >        :returns: An array of max values of measurements for each day.
-> >        """
-> >        return np.max(data, axis=0)
-> >    ~~~
+> >    :param data: A 2D data array with inflammation data (each row contains measurments for a single day across all patients).
+> >    :returns: An array of max values of measurements for each day.
+> >    """
+> >    return np.max(data, axis=0)
+> >~~~
 > > {: .language-python}
 > {: .solution}
 {: .challenge}


### PR DESCRIPTION
[Renato] I would avoid most of the explanations on alternative ways of indenting the code and breaking long lines in favor of introducing tools such as autopep8, yapf or the popular black (https://github.com/psf/black now officially recognized as a Python Software Foundation project).
Most of the lesson would become, code before formatted with black” and “code after” while explaining what black does to respect PEP8.
Black is supported by PyCharm - https://black.readthedocs.io/en/stable/editor_integration.html
[Renato] While I find code style quite important, many modern languages bundle tools in the standard lib to validate or even enforce a given style (Rust, Go, …). This solves the subjective argument that comes with style guides.
Other tools worth mentioning in this context: flake8, pylint, but I guess this might come in a later lesson.
[Renato][Sam] Maximum Line Length: The example using a backslash is incorrect. Should use \ (escape) not / (division).
[Renato] Whitespace in Expressions and Statements: The code example uses python 2 syntax - “print” instead of “print()” but the venv chapter used python 3.7.
I would also avoid the wording “Correct” and “Wrong” which seems to imply that the code will be invalid Python. Use “Yes”/”No” as in the Google Python style linked below. One has to keep in mind that this correct/wrong wording concerns PEP8. Other styles such as Google Python style, following different conventions.
[Sam] Whitespace bit has complicated statement about slicing that isn’t illustrated- adding a `x[:, 1]` would be good.
[Renato] Comments: I wasn’t familiar with the term “block comment”. Is this C terminology? I only know single and multi-line comments. Inline comments being a variation of single-line comments.
[Renato] Comments: In the inline comment example, the text reads “at least two spaces” but the example below actually only has one space before the #..
[Renato] Comments: I really like the “Be kind to your future self” statement when teaching how to write comments. Also I would include the phrasing: “The comment should answer a ‘why’ question”. Occasionally a “what” question. The “how” question is answered by the code itself.
[Renato] Comments: I might have overlooked it but I didn’t read anything on what a good comment should look like. Not including docstrings which I would treat as a separate entity.
[Kamilla] Improve Code Style of Our Project exercise: “in which case only one blank *like* is used.”
[Renato] Docstrings: Please do not refer to triple quoted strings or docstrings as analogous to comments, and even less multi-line comments.. A string in Python, even if unbound still introduces some overhead which a comment does not. A docstring is contextually dependent and is only used by the compiler in specific locations (e.g. top of module and immediately after ‘class’ and ‘def’ keywords). Using triple quoted strings in locations where they will not be interpreted as docstrings is considered bad practice. Same is true for using triple quotes as a way to “quickly” comment out entire blocks of code.
[Renato] Docstrings: Probably worth mentioning that the docstring of the fibonacci function is using Sphinx style for params, raises and returns. Other styles exist as well.
[Renato] Docstrings: In the same paragraph where help() is mentioned, together with Jupyter, it should also be mentioned that PyCharm displays the docstring when using tab-completion.
[Renato] Docstrings: Could be worth mentioning the >>> syntax in docstrings in a callout making a note that this will be revisited later.
[Renato] Docstrings: In exercise “Fix the docstrings” all examples in the solution are indented with 7 spaces which is rather unconventional. 4 would be my expectation given what was used above. Also here the docstrings are formatted with Sphinx/rst style but this syntax hasn’t been explained before. 
[Sam] Docstrings for a function or a module is returned when invoking help function and passing its name -> The docstring for a function or module is returned
Invoking is technically correct but `calling` would be clearer I think?
[Kamilla] Fix the docstrings exercise:  “A 2D data array containing inflammation data (each row contains measurements for a single day).” To me this Implied that there was 1 array per patient with multiple days (1 per row) and multiple measurements per day per person (columns). This is clarified in a later section (see below), but my misconception about the shape of the date initially confused and slowed my progress through this section as I wondered what we were averaging.
